### PR TITLE
Dev attitude setpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build/*
+install/*
+log/*
 dist/*
 __pycache__/
 poetry.lock

--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ In order to launch the mpc quadrotor in a ros2 launchfile,
 ros2 launch px4_mpc mpc_quadrotor_launch.py 
 ```
 
-Use a custom namespace
-```
-ros2 launch px4_mpc mpc_spacecraft_launch.py namespace:=<namespace> 
+The mpc_spacecraft_launch.py file includes optional arguments:
+
+- **mode**: Control mode (wrench by default). Options: wrench, rate, direct_allocation.  
+- **namespace**: Spacecraft namespace ('' by default).  
+- **setpoint_from_rviz**: Use RViz for setpoints (True by default).
+
+**Example:**
+```bash
+ros2 launch px4_mpc mpc_spacecraft_launch.py mode:=wrench namespace:=<namespace> setpoint_from_rviz:=False
 ```

--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ In order to launch the mpc quadrotor in a ros2 launchfile,
 ```
 ros2 launch px4_mpc mpc_quadrotor_launch.py 
 ```
+
+Use a custom namespace
+```
+ros2 launch px4_mpc mpc_spacecraft_launch.py namespace:=<namespace> 
+```

--- a/px4_mpc/px4_mpc/controllers/spacecraft_direct_allocation_mpc.py
+++ b/px4_mpc/px4_mpc/controllers/spacecraft_direct_allocation_mpc.py
@@ -39,7 +39,7 @@ import casadi as cs
 class SpacecraftDirectAllocationMPC():
     def __init__(self, model):
         self.model = model
-        self.Tf = 1.0
+        self.Tf = 5.0
         self.N = 50
 
         self.x0 = np.array([0.01, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
@@ -65,12 +65,12 @@ class SpacecraftDirectAllocationMPC():
         ocp.dims.N = N_horizon
 
         # set cost
-        Q_mat = np.diag([3e1, 3e1, 3e1,
-                         2e1, 2e1, 2e2,
-                         1e2, 1e2, 1e2, 1e2,
-                         1e1, 1e1, 1e1])
+        Q_mat = np.diag([5e1, 5e1, 5e1,
+                         2e3, 2e3, 2e3,
+                         5e2, 5e2, 5e2, 5e2,
+                         3e2, 3e2, 3e2])
         Q_e = 20 * Q_mat
-        R_mat = np.diag([0.5e1] * 4)
+        R_mat = np.diag([1e1] * 4)
 
         ocp.cost.cost_type = 'NONLINEAR_LS'
         ocp.cost.cost_type_e = 'NONLINEAR_LS'
@@ -87,11 +87,14 @@ class SpacecraftDirectAllocationMPC():
         ocp.constraints.lbu = np.array([-Fmax, -Fmax, -Fmax, -Fmax])
         ocp.constraints.ubu = np.array([+Fmax, +Fmax, +Fmax, +Fmax])
         ocp.constraints.idxbu = np.array([0, 1, 2, 3])
+        # ocp.constraints.lbx = np.array([0, -1.54, -10 -0.05, -0.05, -10, -1.01, -1.01, -1.01, -1.01, -10, -10, -10])
+        # ocp.constraints.ubx = np.array([4, 1.5,    10, 0.05,  0.05,  10,  1.01,  1.01,  1.01,  1.01,  10,  10, 10])
+        # ocp.constraints.idxbx = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
 
         ocp.constraints.x0 = x0
 
         # set options
-        ocp.solver_options.qp_solver = 'FULL_CONDENSING_DAQP' # FULL_CONDENSING_QPOASES
+        ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM' # FULL_CONDENSING_QPOASES
         # PARTIAL_CONDENSING_HPIPM, FULL_CONDENSING_QPOASES, FULL_CONDENSING_HPIPM,
         # PARTIAL_CONDENSING_QPDUNES, PARTIAL_CONDENSING_OSQP, FULL_CONDENSING_DAQP
         ocp.solver_options.hessian_approx = 'GAUSS_NEWTON' # 'GAUSS_NEWTON', 'EXACT'

--- a/px4_mpc/px4_mpc/controllers/spacecraft_rate_mpc.py
+++ b/px4_mpc/px4_mpc/controllers/spacecraft_rate_mpc.py
@@ -39,7 +39,7 @@ import casadi as cs
 class SpacecraftRateMPC():
     def __init__(self, model):
         self.model = model
-        self.Tf = 1.0
+        self.Tf = 5.0
         self.N = 50
 
         self.x0 = np.array([0.01, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0])
@@ -66,11 +66,9 @@ class SpacecraftRateMPC():
         ocp.dims.N = N_horizon
 
         # set cost
-        Q_mat = 2*np.diag([10e1, 10e1, 10e1, 100e1, 100e1, 100e1, 1.0, 1.0, 1.0, 1.0])
-        Q_e = 2*np.diag([30e2, 30e2, 30e2, 100e2, 100e2, 100e2, 10.0, 10.0, 10.0, 10.0])
-        R_mat = 2*np.diag([1e1, 1e1, 1e1, 1e1, 1e1, 1e1])
-
-        # TODO: How do you add terminal costs?
+        Q_mat = np.diag([5e1, 5e1, 5e1, 2e3, 2e3, 2e3, 5e2, 5e2, 5e2, 5e2])
+        Q_e = 20 * Q_mat
+        R_mat = 2*np.diag([1e1, 1e1, 1e1, 3e2, 3e2, 3e2])
 
         # the 'EXTERNAL' cost type can be used to define general cost terms
         # NOTE: This leads to additional (exact) hessian contributions when using GAUSS_NEWTON hessian.
@@ -91,8 +89,8 @@ class SpacecraftRateMPC():
         ocp.cost.yref_e = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
 
         # set constraints
-        ocp.constraints.lbu = np.array([-Fmax, -Fmax, -Fmax, -wmax, -wmax, -0.5*wmax])
-        ocp.constraints.ubu = np.array([+Fmax, +Fmax, +Fmax, wmax, wmax, 0.5*wmax])
+        ocp.constraints.lbu = np.array([-Fmax, -Fmax, -Fmax, -wmax, -wmax, -wmax])
+        ocp.constraints.ubu = np.array([+Fmax, +Fmax, +Fmax, wmax, wmax, wmax])
         ocp.constraints.idxbu = np.array([0, 1, 2, 3, 4, 5])
 
         ocp.constraints.x0 = x0

--- a/px4_mpc/px4_mpc/controllers/spacecraft_wrench_mpc.py
+++ b/px4_mpc/px4_mpc/controllers/spacecraft_wrench_mpc.py
@@ -39,7 +39,7 @@ import casadi as cs
 class SpacecraftWrenchMPC():
     def __init__(self, model):
         self.model = model
-        self.Tf = 1.0
+        self.Tf = 5.0
         self.N = 50
 
         self.x0 = np.array([0.01, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
@@ -66,9 +66,12 @@ class SpacecraftWrenchMPC():
         ocp.dims.N = N_horizon
 
         # set cost
-        Q_mat = 2*np.diag([10e1, 10e1, 10e1, 1e1, 1e1, 1e1, 1e1, 1e1, 1e1, 0.0, 0.1, 0.1, 0.1])
-        Q_e   = 2*np.diag([30e2, 30e2, 30e2, 1e2, 1e2, 1e2, 0.0, 0.0, 0.0, 0.0, 1e2, 1e2, 1e2])
-        R_mat = 2*np.diag([1e1, 1e1, 5e0])
+        Q_mat = np.diag([5e1, 5e1, 5e1,
+                         2e3, 2e3, 2e3,
+                         5e2, 5e2, 5e2, 5e2,
+                         3e2, 3e2, 3e2])
+        Q_e = 20 * Q_mat
+        R_mat = 2*np.diag([1e1, 1e1, 1e1])
 
         ocp.cost.cost_type = 'NONLINEAR_LS'
         ocp.cost.cost_type_e = 'NONLINEAR_LS'

--- a/px4_mpc/px4_mpc/controllers/spacecraft_wrench_mpc.py
+++ b/px4_mpc/px4_mpc/controllers/spacecraft_wrench_mpc.py
@@ -1,0 +1,146 @@
+############################################################################
+#
+#   Copyright (C) 2024 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+from acados_template import AcadosOcp, AcadosOcpSolver, AcadosSimSolver
+import numpy as np
+import scipy.linalg
+import casadi as cs
+
+class SpacecraftWrenchMPC():
+    def __init__(self, model):
+        self.model = model
+        self.Tf = 1.0
+        self.N = 50
+
+        self.x0 = np.array([0.01, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+        self.ocp_solver, self.integrator = self.setup(self.x0, self.N, self.Tf)
+
+    def setup(self, x0, N_horizon, Tf):
+        # create ocp object to formulate the OCP
+        ocp = AcadosOcp()
+
+        # set model
+        model = self.model.get_acados_model()
+        Fmax = self.model.max_thrust
+        Tmax = self.model.max_torque
+
+        ocp.model = model
+
+        nx = model.x.size()[0]
+        nu = model.u.size()[0]
+        ny = nx + nu
+        ny_e = nx
+
+        # set dimensions
+        ocp.dims.N = N_horizon
+
+        # set cost
+        Q_mat = 2*np.diag([10e1, 10e1, 10e1, 1e1, 1e1, 1e1, 1e1, 1e1, 1e1, 0.0, 0.1, 0.1, 0.1])
+        Q_e   = 2*np.diag([30e2, 30e2, 30e2, 1e2, 1e2, 1e2, 0.0, 0.0, 0.0, 0.0, 1e2, 1e2, 1e2])
+        R_mat = 2*np.diag([1e1, 1e1, 5e0])
+
+        ocp.cost.cost_type = 'NONLINEAR_LS'
+        ocp.cost.cost_type_e = 'NONLINEAR_LS'
+        ocp.cost.W = scipy.linalg.block_diag(Q_mat, R_mat)
+        ocp.cost.W_e = scipy.linalg.block_diag(Q_e)
+
+
+        ocp.model.cost_y_expr = cs.vertcat(model.x, model.u)
+        ocp.model.cost_y_expr_e = model.x
+        ocp.cost.yref   = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        ocp.cost.yref_e = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+        # set constraints
+        ocp.constraints.lbu = np.array([-Fmax, -Fmax, -Tmax])
+        ocp.constraints.ubu = np.array([+Fmax, +Fmax, +Tmax])
+        ocp.constraints.idxbu = np.array([0, 1, 2])
+
+        ocp.constraints.x0 = x0
+
+        # set options
+        ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM' #'FULL_CONDENSING_DAQP' # FULL_CONDENSING_QPOASES
+        # PARTIAL_CONDENSING_HPIPM, FULL_CONDENSING_QPOASES, FULL_CONDENSING_HPIPM,
+        # PARTIAL_CONDENSING_QPDUNES, PARTIAL_CONDENSING_OSQP, FULL_CONDENSING_DAQP
+        ocp.solver_options.hessian_approx = 'GAUSS_NEWTON' # 'GAUSS_NEWTON', 'EXACT'
+        ocp.solver_options.integrator_type = 'ERK'
+        # ocp.solver_options.print_level = 1
+        use_RTI=True
+        if use_RTI:
+            ocp.solver_options.nlp_solver_type = 'SQP_RTI' # SQP_RTI, SQP
+            ocp.solver_options.sim_method_num_stages = 4
+            ocp.solver_options.sim_method_num_steps = 3
+        else:
+            ocp.solver_options.nlp_solver_type = 'SQP' # SQP_RTI, SQP
+
+        ocp.solver_options.qp_solver_cond_N = N_horizon
+
+        # set prediction horizon
+        ocp.solver_options.tf = Tf
+
+        ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json')
+        # create an integrator with the same settings as used in the OCP solver.
+        acados_integrator = AcadosSimSolver(ocp, json_file = 'acados_ocp.json')
+
+        return ocp_solver, acados_integrator
+
+    def solve(self, x0, verbose=False):
+
+        # preparation phase
+        ocp_solver = self.ocp_solver
+
+        # set initial state
+        ocp_solver.set(0, "lbx", x0)
+        ocp_solver.set(0, "ubx", x0)
+
+        status = ocp_solver.solve()
+        if verbose:
+            self.ocp_solver.print_statistics() # encapsulates: stat = ocp_solver.get_stats("statistics")
+
+        if status != 0:
+            raise Exception(f'acados returned status {status}.')
+
+        N = self.N
+        nx = self.model.get_acados_model().x.size()[0]
+        nu = self.model.get_acados_model().u.size()[0]
+
+        simX = np.ndarray((N+1, nx))
+        simU = np.ndarray((N, nu))
+
+        # get solution
+        for i in range(N):
+            simX[i,:] = self.ocp_solver.get(i, "x")
+            simU[i,:] = self.ocp_solver.get(i, "u")
+        simX[N,:] = self.ocp_solver.get(N, "x")
+
+        return simU, simX

--- a/px4_mpc/px4_mpc/launch/mpc_spacecraft_launch.py
+++ b/px4_mpc/px4_mpc/launch/mpc_spacecraft_launch.py
@@ -37,26 +37,41 @@ __contact__ = "padr@kth.se, jalim@ethz.ch"
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration
+from launch.conditions import IfCondition
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 import os
 
 
 def generate_launch_description():
-    # Declare namespace argument
+    # Declare launch arguments
+    mode_arg = DeclareLaunchArgument(
+        'mode',
+        default_value='wrench',
+        description='Mode of the controller (rate, wrench, direct_allocation)'
+    )
+    
     namespace_arg = DeclareLaunchArgument(
         'namespace',
         default_value='',  # Default namespace is empty
         description='Namespace for all nodes'
     )
 
-    # Get and process the namespace value
+    setpoint_from_rviz_arg = DeclareLaunchArgument(
+        'setpoint_from_rviz',
+        default_value='true',
+        description='Publish setpoint pose via rviz'
+    )
+
+    mode = LaunchConfiguration('mode')
     namespace = LaunchConfiguration('namespace')
+    setpoint_from_rviz = LaunchConfiguration('setpoint_from_rviz')
 
     return LaunchDescription([
+        mode_arg,
         namespace_arg,
-
+        setpoint_from_rviz_arg,
         Node(
             package='px4_mpc',
             namespace=namespace,
@@ -65,8 +80,9 @@ def generate_launch_description():
             output='screen',
             emulate_tty=True,
             parameters=[
-                {'mode': 'direct_allocation'},
-                {'namespace': namespace}
+                {'mode': mode},
+                {'namespace': namespace},
+                {'setpoint_from_rviz': setpoint_from_rviz}
             ]
         ),
         Node(
@@ -78,14 +94,9 @@ def generate_launch_description():
             emulate_tty=True,
             parameters=[
                 {'namespace': namespace}
-            ]
+            ],
+            condition=IfCondition(LaunchConfiguration('setpoint_from_rviz'))
         ),
-        # Node(
-        #     package='micro_ros_agent',
-        #     executable='micro_ros_agent',
-        #     arguments=['udp4', '-p', '8888'],
-        #     parameters=[{'use_sim_time': 1}],
-        #     output='screen'),
         Node(
             package='px4_offboard',
             namespace=namespace,
@@ -93,7 +104,8 @@ def generate_launch_description():
             name='visualizer',
             parameters=[
                 {'namespace': namespace}
-            ]
+            ],
+            condition=IfCondition(LaunchConfiguration('setpoint_from_rviz'))
         ),
         Node(
             package='rviz2',
@@ -101,5 +113,6 @@ def generate_launch_description():
             executable='rviz2',
             name='rviz2',
             arguments=['-d', os.path.join(get_package_share_directory('px4_mpc'), 'config.rviz')],
+            condition=IfCondition(LaunchConfiguration('setpoint_from_rviz'))
         ),
     ])

--- a/px4_mpc/px4_mpc/launch/mpc_spacecraft_launch.py
+++ b/px4_mpc/px4_mpc/launch/mpc_spacecraft_launch.py
@@ -36,29 +36,49 @@ __author__ = "Pedro Roque, Jaeyoung Lim"
 __contact__ = "padr@kth.se, jalim@ethz.ch"
 
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 import os
 
 
 def generate_launch_description():
+    # Declare namespace argument
+    namespace_arg = DeclareLaunchArgument(
+        'namespace',
+        default_value='',  # Default namespace is empty
+        description='Namespace for all nodes'
+    )
+
+    # Get and process the namespace value
+    namespace = LaunchConfiguration('namespace')
+
     return LaunchDescription([
+        namespace_arg,
+
         Node(
             package='px4_mpc',
-            namespace='px4_mpc',
+            namespace=namespace,
             executable='mpc_spacecraft',
             name='mpc_spacecraft',
             output='screen',
             emulate_tty=True,
-            parameters=[{'mode': 'wrench'}], # rate/wrench/direct_allocation
+            parameters=[
+                {'mode': 'wrench'},
+                {'namespace': namespace}
+            ]
         ),
         Node(
             package='px4_mpc',
-            namespace='px4_mpc',
+            namespace=namespace,
             executable='rviz_pos_marker',
             name='rviz_pos_marker',
             output='screen',
             emulate_tty=True,
+            parameters=[
+                {'namespace': namespace}
+            ]
         ),
         # Node(
         #     package='micro_ros_agent',
@@ -68,15 +88,18 @@ def generate_launch_description():
         #     output='screen'),
         Node(
             package='px4_offboard',
-            namespace='px4_offboard',
+            namespace=namespace,
             executable='visualizer',
-            name='visualizer'
+            name='visualizer',
+            parameters=[
+                {'namespace': namespace}
+            ]
         ),
         Node(
             package='rviz2',
             namespace='',
             executable='rviz2',
             name='rviz2',
-            arguments=['-d', [os.path.join(get_package_share_directory('px4_mpc'), 'config.rviz')]]
-        )
+            arguments=['-d', os.path.join(get_package_share_directory('px4_mpc'), 'config.rviz')],
+        ),
     ])

--- a/px4_mpc/px4_mpc/launch/mpc_spacecraft_launch.py
+++ b/px4_mpc/px4_mpc/launch/mpc_spacecraft_launch.py
@@ -65,7 +65,7 @@ def generate_launch_description():
             output='screen',
             emulate_tty=True,
             parameters=[
-                {'mode': 'wrench'},
+                {'mode': 'direct_allocation'},
                 {'namespace': namespace}
             ]
         ),

--- a/px4_mpc/px4_mpc/launch/mpc_spacecraft_launch.py
+++ b/px4_mpc/px4_mpc/launch/mpc_spacecraft_launch.py
@@ -50,6 +50,7 @@ def generate_launch_description():
             name='mpc_spacecraft',
             output='screen',
             emulate_tty=True,
+            parameters=[{'mode': 'wrench'}], # rate/wrench/direct_allocation
         ),
         Node(
             package='px4_mpc',

--- a/px4_mpc/px4_mpc/models/spacecraft_rate_model.py
+++ b/px4_mpc/px4_mpc/models/spacecraft_rate_model.py
@@ -39,8 +39,8 @@ class SpacecraftRateModel():
         self.name = 'spacecraft_rate_model'
 
         # constants
-        self.mass = 15.
-        self.max_thrust = 1.
+        self.mass = 15.0
+        self.max_thrust = 1.5
         self.max_rate = 0.5
 
     def get_acados_model(self) -> AcadosModel:

--- a/px4_mpc/px4_mpc/models/spacecraft_wrench_model.py
+++ b/px4_mpc/px4_mpc/models/spacecraft_wrench_model.py
@@ -1,0 +1,116 @@
+############################################################################
+#
+#   Copyright (C) 2024 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+from acados_template import AcadosModel
+import casadi as cs
+import numpy as np
+
+class SpacecraftWrenchModel():
+    def __init__(self):
+        self.name = 'spacecraft_direct_allocation_model'
+
+        # constants
+        self.mass = 15.
+        self.inertia = np.diag((0.1454, 0.1366, 0.1594))
+        self.max_thrust = 1.5
+        self.max_torque = 0.5
+
+    def get_acados_model(self) -> AcadosModel:
+        def skew_symmetric(v):
+            return cs.vertcat(cs.horzcat(0, -v[0], -v[1], -v[2]),
+                cs.horzcat(v[0], 0, v[2], -v[1]),
+                cs.horzcat(v[1], -v[2], 0, v[0]),
+                cs.horzcat(v[2], v[1], -v[0], 0))
+
+        def q_to_rot_mat(q):
+            qw, qx, qy, qz = q[0], q[1], q[2], q[3]
+
+            rot_mat = cs.vertcat(
+                cs.horzcat(1 - 2 * (qy ** 2 + qz ** 2), 2 * (qx * qy - qw * qz), 2 * (qx * qz + qw * qy)),
+                cs.horzcat(2 * (qx * qy + qw * qz), 1 - 2 * (qx ** 2 + qz ** 2), 2 * (qy * qz - qw * qx)),
+                cs.horzcat(2 * (qx * qz - qw * qy), 2 * (qy * qz + qw * qx), 1 - 2 * (qx ** 2 + qy ** 2)))
+
+            return rot_mat
+
+        def v_dot_q(v, q):
+            rot_mat = q_to_rot_mat(q)
+
+            return cs.mtimes(rot_mat, v)
+
+        model = AcadosModel()
+
+        # set up states & controls
+        p      = cs.MX.sym('p', 3)
+        v      = cs.MX.sym('v', 3)
+        q      = cs.MX.sym('q', 4)
+        w      = cs.MX.sym('w', 3)
+
+        x = cs.vertcat(p, v, q, w)
+        u = cs.MX.sym('u', 3)
+
+        D_mat = cs.MX.zeros(3, 3)
+        D_mat[0, 0] = 1
+        D_mat[1, 1] = 1
+        D_mat[2, 2] = 1
+        F_2d = cs.mtimes(D_mat, u)
+
+        F = cs.vertcat(F_2d[0,0], F_2d[1,0], 0.0)
+        tau = cs.vertcat(0.0, 0.0, F_2d[2,0])
+
+        # xdot
+        p_dot      = cs.MX.sym('p_dot', 3)
+        v_dot      = cs.MX.sym('v_dot', 3)
+        q_dot      = cs.MX.sym('q_dot', 4)
+        w_dot      = cs.MX.sym('w_dot', 3)
+
+        xdot = cs.vertcat(p_dot, v_dot, q_dot, w_dot)
+
+        a_thrust = v_dot_q(F, q)/self.mass
+
+        # dynamics
+        f_expl = cs.vertcat(v,
+                            a_thrust,
+                            1 / 2 * cs.mtimes(skew_symmetric(w), q),
+                            np.linalg.inv(self.inertia) @ (tau - cs.cross(w, self.inertia @ w))
+                            )
+
+        f_impl = xdot - f_expl
+
+        model.f_impl_expr = f_impl
+        model.f_expl_expr = f_expl
+        model.x = x
+        model.xdot = xdot
+        model.u = u
+        model.name = self.name
+
+        return model

--- a/px4_mpc/px4_mpc/mpc_spacecraft.py
+++ b/px4_mpc/px4_mpc/mpc_spacecraft.py
@@ -69,7 +69,7 @@ def vector2PoseMsg(frame_id, position, attitude):
     pose_msg.pose.position.z = float(position[2])
     return pose_msg
 
-class QuadrotorMPC(Node):
+class SpacecraftMPC(Node):
 
     def __init__(self):
         super().__init__('minimal_publisher')
@@ -110,7 +110,7 @@ class QuadrotorMPC(Node):
 
         self.nav_state = VehicleStatus.NAVIGATION_STATE_MAX
 
-        # Create Quadrotor and controller objects
+        # Create Spacecraft and controller objects
         self.model = SpacecraftRateModel()
 
         # Spawn Controller
@@ -221,11 +221,11 @@ class QuadrotorMPC(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    quadrotor_mpc = QuadrotorMPC()
+    spacecraft_mpc = SpacecraftMPC()
 
-    rclpy.spin(quadrotor_mpc)
+    rclpy.spin(spacecraft_mpc)
 
-    quadrotor_mpc.destroy_node()
+    spacecraft_mpc.destroy_node()
     rclpy.shutdown()
 
 

--- a/px4_mpc/px4_mpc/mpc_spacecraft.py
+++ b/px4_mpc/px4_mpc/mpc_spacecraft.py
@@ -324,7 +324,7 @@ class SpacecraftMPC(Node):
                            error_attitude[1],
                            error_attitude[2],
                            error_attitude[3]]).reshape(10, 1)
-        elif self.mode == 'direct_allocation':
+        elif self.mode == 'direct_allocation' or self.mode == 'wrench':
             x0 = np.array([error_position[0],
                            error_position[1],
                            error_position[2],

--- a/px4_mpc/px4_mpc/mpc_spacecraft.py
+++ b/px4_mpc/px4_mpc/mpc_spacecraft.py
@@ -79,12 +79,26 @@ def vector2PoseMsg(frame_id, position, attitude):
 class SpacecraftMPC(Node):
 
     def __init__(self):
-        super().__init__('minimal_publisher')
-        qos_profile = QoSProfile(
-            reliability=QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,
-            durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
-            history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
-            depth=1
+        super().__init__('spacecraft_mpc')
+
+        # Declare and retrieve the namespace parameter
+        self.declare_parameter('namespace', '')  # Default to empty namespace
+        self.namespace = self.get_parameter('namespace').value
+        self.namespace_prefix = f'/{self.namespace}' if self.namespace else ''
+
+        # QoS profiles
+        qos_profile_pub = QoSProfile(
+            reliability=QoSReliabilityPolicy.BEST_EFFORT,
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+            history=QoSHistoryPolicy.KEEP_LAST,
+            depth=0
+        )
+
+        qos_profile_sub = QoSProfile(
+            reliability=QoSReliabilityPolicy.BEST_EFFORT,
+            durability=QoSDurabilityPolicy.VOLATILE,
+            history=QoSHistoryPolicy.KEEP_LAST,
+            depth=0
         )
 
         # Get mode; rate, wrench, direct_allocation
@@ -92,41 +106,41 @@ class SpacecraftMPC(Node):
 
         self.status_sub = self.create_subscription(
             VehicleStatus,
-            '/fmu/out/vehicle_status',
+            f'{self.namespace_prefix}/fmu/out/vehicle_status',
             self.vehicle_status_callback,
-            qos_profile)
+            qos_profile_sub)
 
         self.attitude_sub = self.create_subscription(
             VehicleAttitude,
-            '/fmu/out/vehicle_attitude',
+            f'{self.namespace_prefix}/fmu/out/vehicle_attitude',
             self.vehicle_attitude_callback,
-            qos_profile)
+            qos_profile_sub)
         self.angular_vel_sub = self.create_subscription(
             VehicleAngularVelocity,
-            '/fmu/out/vehicle_angular_velocity',
+            f'{self.namespace_prefix}/fmu/out/vehicle_angular_velocity',
             self.vehicle_angular_velocity_callback,
-            qos_profile)
+            qos_profile_sub)
         self.angular_vel_sub = self.create_subscription(
             VehicleAngularVelocity,
-            '/fmu/out/vehicle_angular_velocity',
+            f'{self.namespace_prefix}/fmu/out/vehicle_angular_velocity',
             self.vehicle_angular_velocity_callback,
-            qos_profile)
+            qos_profile_sub)
         self.local_position_sub = self.create_subscription(
             VehicleLocalPosition,
-            '/fmu/out/vehicle_local_position',
+            f'{self.namespace_prefix}/fmu/out/vehicle_local_position',
             self.vehicle_local_position_callback,
-            qos_profile)
+            qos_profile_sub)
 
-        self.set_pose_srv = self.create_service(SetPose, '/set_pose', self.add_set_pos_callback)
+        self.set_pose_srv = self.create_service(SetPose, f'{self.namespace_prefix}/set_pose', self.add_set_pos_callback)
 
-        self.publisher_offboard_mode = self.create_publisher(OffboardControlMode, '/fmu/in/offboard_control_mode', qos_profile)
-        self.publisher_rates_setpoint = self.create_publisher(VehicleRatesSetpoint, '/fmu/in/vehicle_rates_setpoint', qos_profile)
-        self.publisher_direct_actuator = self.create_publisher(ActuatorMotors, '/fmu/in/actuator_motors', qos_profile)
-        self.publisher_thrust_setpoint = self.create_publisher(VehicleThrustSetpoint, '/fmu/in/vehicle_thrust_setpoint', qos_profile)
-        self.publisher_torque_setpoint = self.create_publisher(VehicleTorqueSetpoint, '/fmu/in/vehicle_torque_setpoint', qos_profile)
-        self.predicted_path_pub = self.create_publisher(Path, '/px4_mpc/predicted_path', 10)
-        self.reference_pub = self.create_publisher(Marker, "/px4_mpc/reference", 10)
-        self.reference_pub = self.create_publisher(Marker, "/px4_mpc/reference", 10)
+        self.publisher_offboard_mode = self.create_publisher(OffboardControlMode, f'{self.namespace_prefix}/fmu/in/offboard_control_mode', qos_profile_pub)
+        self.publisher_rates_setpoint = self.create_publisher(VehicleRatesSetpoint, f'{self.namespace_prefix}/fmu/in/vehicle_rates_setpoint', qos_profile_pub)
+        self.publisher_direct_actuator = self.create_publisher(ActuatorMotors, f'{self.namespace_prefix}/fmu/in/actuator_motors', qos_profile_pub)
+        self.publisher_thrust_setpoint = self.create_publisher(VehicleThrustSetpoint, f'{self.namespace_prefix}/fmu/in/vehicle_thrust_setpoint', qos_profile_pub)
+        self.publisher_torque_setpoint = self.create_publisher(VehicleTorqueSetpoint, f'{self.namespace_prefix}/fmu/in/vehicle_torque_setpoint', qos_profile_pub)
+        self.predicted_path_pub = self.create_publisher(Path, f'{self.namespace_prefix}/px4_mpc/predicted_path', 10)
+        self.reference_pub = self.create_publisher(Marker, f"{self.namespace_prefix}/px4_mpc/reference", 10)
+        self.reference_pub = self.create_publisher(Marker, f"{self.namespace_prefix}/px4_mpc/reference", 10)
 
         timer_period = 0.02  # seconds
         self.timer = self.create_timer(timer_period, self.cmdloop_callback)

--- a/px4_mpc/px4_mpc/mpc_spacecraft.py
+++ b/px4_mpc/px4_mpc/mpc_spacecraft.py
@@ -120,11 +120,6 @@ class SpacecraftMPC(Node):
             f'{self.namespace_prefix}/fmu/out/vehicle_angular_velocity',
             self.vehicle_angular_velocity_callback,
             qos_profile_sub)
-        self.angular_vel_sub = self.create_subscription(
-            VehicleAngularVelocity,
-            f'{self.namespace_prefix}/fmu/out/vehicle_angular_velocity',
-            self.vehicle_angular_velocity_callback,
-            qos_profile_sub)
         self.local_position_sub = self.create_subscription(
             VehicleLocalPosition,
             f'{self.namespace_prefix}/fmu/out/vehicle_local_position',
@@ -139,7 +134,6 @@ class SpacecraftMPC(Node):
         self.publisher_thrust_setpoint = self.create_publisher(VehicleThrustSetpoint, f'{self.namespace_prefix}/fmu/in/vehicle_thrust_setpoint', qos_profile_pub)
         self.publisher_torque_setpoint = self.create_publisher(VehicleTorqueSetpoint, f'{self.namespace_prefix}/fmu/in/vehicle_torque_setpoint', qos_profile_pub)
         self.predicted_path_pub = self.create_publisher(Path, f'{self.namespace_prefix}/px4_mpc/predicted_path', 10)
-        self.reference_pub = self.create_publisher(Marker, f"{self.namespace_prefix}/px4_mpc/reference", 10)
         self.reference_pub = self.create_publisher(Marker, f"{self.namespace_prefix}/px4_mpc/reference", 10)
 
         timer_period = 0.02  # seconds
@@ -232,7 +226,7 @@ class SpacecraftMPC(Node):
     def publish_rate_setpoint(self, u_pred):
         thrust_rates = u_pred[0, :]
         # Hover thrust = 0.73
-        thrust_command = thrust_rates[0:3] * 0.07  # NOTE: Tune in thrust multiplier
+        thrust_command = thrust_rates[0:3]
         rates_setpoint_msg = VehicleRatesSetpoint()
         rates_setpoint_msg.timestamp = int(Clock().now().nanoseconds / 1000)
         rates_setpoint_msg.roll  = float(thrust_rates[3])

--- a/px4_mpc/px4_mpc/rviz_pos_marker.py
+++ b/px4_mpc/px4_mpc/rviz_pos_marker.py
@@ -158,7 +158,13 @@ class MinimalClientAsync(Node):
 
     def __init__(self):
         super().__init__('minimal_client_async')
-        self.cli = self.create_client(SetPose, '/set_pose')
+
+        # Declare and retrieve the namespace parameter
+        self.declare_parameter('namespace', '')  # Default to empty namespace
+        self.namespace = self.get_parameter('namespace').value
+        self.namespace_prefix = f'/{self.namespace}' if self.namespace else ''
+
+        self.cli = self.create_client(SetPose, f'{self.namespace_prefix}/set_pose')
         while not self.cli.wait_for_service(timeout_sec=1.0):
             self.get_logger().info('service not available, waiting again...')
         self.req = SetPose.Request()


### PR DESCRIPTION
Added option for spacecraft launch file to not use rviz. 

The mpc_spacecraft_launch.py file includes optional arguments:

- **mode**: Control mode (wrench by default). Options: wrench, rate, direct_allocation.  
- **namespace**: Spacecraft namespace ('' by default).  
- **setpoint_from_rviz**: Use RViz for setpoints (True by default).

**Example:**
```bash
ros2 launch px4_mpc mpc_spacecraft_launch.py mode:=wrench namespace:=<namespace> setpoint_from_rviz:=False
```